### PR TITLE
ISSUE: #39 - file-server.Dockerfile does not build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugs
 
+- [#39](https://github.com/DFE-Digital/polis-whitelabel/issues/39) Fix to #37 so that file-server.Dockerfile now builds with latest versions
 - [#37](https://github.com/DFE-Digital/polis-whitelabel/issues/37) Migrated client-report from Gulp 3 to Webpack
 - [#30](https://github.com/DFE-Digital/polis-whitelabel/issues/30) Migrated client-admin from Gulp 3 to Webpack
 - [#5](https://github.com/DFE-Digital/polis-whitelabel/issues/5) Restored Docker build process

--- a/deploy/docker/file-server.Dockerfile
+++ b/deploy/docker/file-server.Dockerfile
@@ -1,7 +1,7 @@
 
-FROM --platform=linux/amd64 docker.io/node:16.14.2-alpine AS client-base
+FROM --platform=linux/amd64 docker.io/node:18.12.1-alpine AS client-base
 
-RUN apk add git g++ make python2 openssh --no-cache
+RUN apk add git --no-cache
 
 # polis-client-admin
 FROM client-base AS client-admin
@@ -13,7 +13,6 @@ COPY file-server/polis.config.js polis.config.js
 
 RUN npm install
 
-ARG GIT_HASH
 RUN npm run build:prod
 
 


### PR DESCRIPTION
**Addresses issue #39**

In #37 the Dockerfile for file-server was updated but did not build correctly. Partly due to `python2` no longer being in the latest Alpine distribution.

* Removes dependencies needed only for `node-sass` building
* Updates to Node 18.12.1 for all client components
* Updated to latest Alpine
* Remove a redundant `GIT_HASH` declaration