### PR TITLE
ISSUE: #53 - Fix server build devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,7 +17,7 @@ RUN yes | unminimize 2>&1 \
 
 # # In this instance we add the psql command so we can access the database from the command line
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends postgresql-client 
+    && apt-get -y install --no-install-recommends postgresql-client libpq-dev
 
 # [Choice] Ubuntu version (use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon): ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
 # ARG VARIANT=ubuntu-20.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugs
 
+- [#53](https://github.com/DFE-Digital/polis-whitelabel/issues/53) Fix missing `libpq-dev` dependency when building `server` in Devcontainer
 - [#45](https://github.com/DFE-Digital/polis-whitelabel/issues/45) Update `file-server` to update dependencies in Dockerfile
 - [#41](https://github.com/DFE-Digital/polis-whitelabel/issues/39) Update `server` to run a new version of Node and update dependencies
 - [#42](https://github.com/DFE-Digital/polis-whitelabel/issues/42) Fix to crash when voting anonymously and remove legacy IP logging


### PR DESCRIPTION
**Addresses #53**

* Adds missing `libpq-dev` dependency to the Devcontainer Ubuntu image on install so that `npm install` now works for `server`