### PR TITLE
ISSUE: #58 - polis-math filling container with error logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bugs
 
 - [#59](https://github.com/DFE-Digital/polis-whitelabel/issues/59) Remove server headers from example production configuration/Update devcontainer
+- [#58](https://github.com/DFE-Digital/polis-whitelabel/issues/58) `polis-math` filling container with `errorconv.*.edn` files
 - [#53](https://github.com/DFE-Digital/polis-whitelabel/issues/53) Fix missing `libpq-dev` dependency when building `server` in Devcontainer
 - [#49](https://github.com/DFE-Digital/polis-whitelabel/issues/49) Updated/removed vulnerable math dependencies including AWS housekeeping functions
 - [#48](https://github.com/DFE-Digital/polis-whitelabel/issues/48) Fix a XSS bug where HTML & Javascript can be dropped into description field

--- a/math/.gitignore
+++ b/math/.gitignore
@@ -10,3 +10,4 @@
 /target
 pom.xml
 pom.xml.asc
+errorconv.LATEST.edn

--- a/math/src/polismath/math/conversation.clj
+++ b/math/src/polismath/math/conversation.clj
@@ -900,7 +900,7 @@
 (defn conv-update-dump
   "Write out conversation state, votes, computational opts and error for debugging purposes."
   [conv votes & [opts error]]
-  (spit (str "errorconv." (. System (nanoTime)) ".edn")
+  (spit (str "errorconv.LATEST.edn")
     (prn-str
       {:conv  (into {}
                 (assoc-in conv [:pca :center] (matrix/matrix (into [] (:center (:pca conv))))))


### PR DESCRIPTION
**Addresses issue #58**

* Math error log dumps now overwrite each other so consistent errors don't fill the disk
* Added math error logs to gitignore

## Checklist

- [x] Title is in format `ISSUE: #XX - Brief description`
- [x] I have updated `CHANGELOG.md`
- [x] I have run `e2e` tests and fixed any failures