### PR TITLE
ISSUE: #83 - Fix broken Twemoji images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugs
 
+- [#83](https://github.com/DFE-Digital/polis-whitelabel/issues/83) Fix broken Twemoji image URLs
 - [#76](https://github.com/DFE-Digital/polis-whitelabel/issues/76) Fix pull request template
 - [#59](https://github.com/DFE-Digital/polis-whitelabel/issues/59) Remove server headers from example production configuration/Update devcontainer
 - [#58](https://github.com/DFE-Digital/polis-whitelabel/issues/58) `polis-math` filling container with `errorconv.*.edn` files

--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -11,7 +11,7 @@ import {
 import ComponentHelpers from '../../util/component-helpers'
 import NoPermission from './no-permission'
 import { Heading, Box, Text, jsx } from 'theme-ui'
-import emoji from 'react-easy-emoji'
+import emoji from '../framework/custom-emoji'
 
 import { CheckboxField } from './CheckboxField'
 import ModerateCommentsSeed from './seed-comment'

--- a/client-admin/src/components/framework/custom-emoji.js
+++ b/client-admin/src/components/framework/custom-emoji.js
@@ -1,0 +1,12 @@
+/** @jsx jsx */
+import emoji from 'react-easy-emoji'
+
+function customEmoji(input) {
+  return emoji(input, {
+    baseUrl: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/',
+    size: '72x72'
+  })
+}
+
+
+export default customEmoji

--- a/client-admin/src/components/landers/knowledgeBase.js
+++ b/client-admin/src/components/landers/knowledgeBase.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Link } from 'theme-ui'
-import emoji from 'react-easy-emoji'
+import emoji from '../framework/custom-emoji'
 
 const KnowledgeBase = ({ e, url, txt }) => {
   return (

--- a/client-admin/src/components/landers/lander-footer.js
+++ b/client-admin/src/components/landers/lander-footer.js
@@ -2,7 +2,7 @@
 import { Component } from 'react'
 import { Box, Link, Heading, jsx } from 'theme-ui'
 
-import emoji from 'react-easy-emoji'
+import emoji from '../framework/custom-emoji'
 
 class Header extends Component {
   render() {


### PR DESCRIPTION
Addresses issue #83 

Changes the CDN from MaxCDN (which is now down) to jsDelivr

  * [x] I have updated CHANGELOG.md
  * [ ] I have run e2e tests and fixed any failures (will let CI run)
  * [ ] I have run clojure -M:test and fixed any failures (will let CI run)