### PR TITLE
ISSUE: #91 - Allow no email transports to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugs
 
+- [#91](https://github.com/DFE-Digital/polis-whitelabel/issues/91) Allow no email transport to be configured without crash
 - [#87](https://github.com/DFE-Digital/polis-whitelabel/issues/85) Client report no longer hardcoded to pol.is domain
 - [#85](https://github.com/DFE-Digital/polis-whitelabel/issues/85) Fix local Docker Compose script
 - [#83](https://github.com/DFE-Digital/polis-whitelabel/issues/83) Fix broken Twemoji image URLs

--- a/server/src/email/senders.ts
+++ b/server/src/email/senders.ts
@@ -15,6 +15,9 @@ function sendTextEmailWithBackup(
   subject: any,
   text: any
 ) {
+  if (!process.env.EMAIL_TRANSPORT_TYPES) {
+    return
+  }
   const transportTypes = process.env.EMAIL_TRANSPORT_TYPES
     ? process.env.EMAIL_TRANSPORT_TYPES.split(",")
     : ["aws-ses", "mailgun"];
@@ -61,10 +64,10 @@ function sendTextEmail(
   text: string | undefined,
   transportTypes = process.env.EMAIL_TRANSPORT_TYPES,
   priority = 1
-): Promise<SMTPTransport.SentMessageInfo>  {
+): Promise<SMTPTransport.SentMessageInfo | undefined>  {
   // Exit if empty string passed.
   if (!transportTypes) {
-    return Promise.reject('no_email_transport_defined');
+    return Promise.resolve(undefined)
   }
 
   const transportTypesArray = transportTypes.split(",");


### PR DESCRIPTION
**Addresses issue #91**

The GovUK use case does not currently implement an email service but not configuring one causes the app to crash. This change allows email sending to be disabled by not including any mail transports in the configuration

## Checklist

- [x] Title is in format `ISSUE: #XX - Brief description`
- [x] I have updated `CHANGELOG.md`
- [x] I have run `e2e` tests and fixed any failures
- [x] I have run `clojure -M:test` and fixed any failures
